### PR TITLE
fix for issue 3328

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -46,8 +46,8 @@ var Instruments = function (opts) {
                  "`ignoreStartupExit` option instead");
   }
   this.ignoreStartupExit = opts.ignoreStartupExit || opts.isSafariLauncherApp;
-  this.bootstrap = opts.bootstrap;
-  this.template = opts.template;
+  this.bootstrap = "\"" + opts.bootstrap + "\"";
+  this.template = "\"" + opts.template + "\"";
   this.withoutDelay = opts.withoutDelay;
   this.xcodeVersion = opts.xcodeVersion;
   this.webSocket = opts.webSocket;


### PR DESCRIPTION
passing bootstrap location in quoted string for temporary location with spaces in path
