### PR TITLE
when instruments dies in safarilauncher context, we still need to call t...

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -113,6 +113,7 @@ Instruments.getInstrumentsPath = function (cb) {
 
 Instruments.prototype.start = function (cb, unexpectedExitCb) {
   cb = cb || function () {};
+  this.postLaunchHandler = cb;
   unexpectedExitCb = unexpectedExitCb || function () {};
   if (this.didLaunch) {
     return cb(new Error("Called start() but we already launched"));
@@ -150,9 +151,10 @@ Instruments.prototype.launchHandler = function (err) {
       this.neverConnected = false;
     } else {
       Instruments.killAll();
-      if (this.launchTries < this.flakeyRetries &&
-          (err.message === ERR_NEVER_CHECKED_IN ||
-           err.message === ERR_CRASHED_ON_STARTUP)) {
+      var errIsCatchable = err.message === ERR_NEVER_CHECKED_IN ||
+                           err.message === ERR_CRASHED_ON_STARTUP;
+      logger.debug(err.message);
+      if (this.launchTries < this.flakeyRetries && errIsCatchable) {
         this.launchTries++;
         logger.debug("Attempting to retry launching instruments, this is " +
                     "retry #" + this.launchTries);
@@ -163,9 +165,11 @@ Instruments.prototype.launchHandler = function (err) {
             if (err) return this.launchHandler(err);
           }.bind(this));
         }.bind(this), 5000);
-        return;
+      } else if (errIsCatchable) {
+        logger.debug("We exceeded the number of retries allowed for " +
+                     "instruments to successfully start; failing launch");
+        this.postLaunchHandler(err);
       }
-      logger.debug(err.message);
     }
   } else {
     logger.debug("Trying to call back from instruments launch but we " +
@@ -281,7 +285,8 @@ Instruments.prototype.launch = function (cb) {
 
 Instruments.prototype.spawnInstruments = function () {
   var traceDir;
-  for (var i=0; ; i++) {
+  for (var i = 0; ; i++) {
+    // loop while there are tracedirs to delete
     traceDir = path.resolve(this.traceDir, 'instrumentscli' + i + '.trace');
     if (!fs.existsSync(traceDir)) break;
   }
@@ -344,7 +349,7 @@ Instruments.prototype.onInstrumentsExit = function (code) {
   if (this.ignoreStartupExit) {
     logger.debug("Not worrying about instruments exit since we're using " +
                 "SafariLauncher");
-    this.launchHandler();
+    this.postLaunchHandler();
   } else if (this.shutdownCb !== null) {
     this.shutdownCb();
     this.shutdownCb = null;


### PR DESCRIPTION
...he unexpected exit cb, otherwise appium will never have a chance to catch it and continue

cc @snevesbarros
