### PR TITLE
Put quotes around path.  By default, Xcode side by side installs of 5 & ...

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -90,7 +90,7 @@ Instruments.getAvailableDevices = function (cb) {
   Instruments.getInstrumentsPath(function (err, instrumentsPath) {
     if (err) return cb(err);
     var opts = {timeout: INST_STALL_TIMEOUT};
-    exec(instrumentsPath + " -s devices", opts, function (err, stdout) {
+    exec("'" + instrumentsPath + "' -s devices", opts, function (err, stdout) {
       if (err) return cb(err);
       var devices = [];
       _.each(stdout.split("\n"), function (line) {


### PR DESCRIPTION
I put quotes around path for instrumentation call to get device list.  On my side by side Xcode installs of 5 & 6, put 6 in 'Xcode 2.app'.  I was getting this error:

error: Failed to start an Appium session, err was: Error: Command failed: /bin/sh: /Applications/Xcode: No such file or directory
