### PR TITLE
Refactor

### DIFF
--- a/lib/future.js
+++ b/lib/future.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var nodeifyModule = require('appium-support').util.nodeifyModule,
+    xcode = require('appium-xcode');
+
+module.exports = {
+  xcode: nodeifyModule(xcode)
+};

--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -11,6 +11,7 @@ var spawn = require('child_process').spawn,
     rimraf = require('rimraf'),
     async = require('async'),
     mkdirp = require('mkdirp'),
+    xcode = require('./future.js').xcode,
     fs = require('fs');
 
 var ERR_NEVER_CHECKED_IN = "Instruments never checked in",
@@ -53,7 +54,6 @@ var Instruments = function (opts) {
   this.bootstrap = opts.bootstrap;
   this.template = opts.template;
   this.withoutDelay = opts.withoutDelay;
-  this.xcodeVersion = opts.xcodeVersion;
   this.webSocket = opts.webSocket;
   this.resultHandler = this.defaultResultHandler;
   this.exitHandler = this.defaultExitHandler;
@@ -69,23 +69,20 @@ var Instruments = function (opts) {
   this.tmpDir = opts.tmpDir || '/tmp/appium-instruments';
   this.traceDir = opts.traceDir || this.tmpDir;
   this.gotFBSOpenApplicationError = false;
-
-  if (this.xcodeVersion && this.xcodeVersion.slice(0, 3) === '6.0' && this.withoutDelay) {
-    logger.info("On xcode 6.0, instruments-without-delay does " +
-                "not work. If using appium, you can disable instruments-without-delay " +
-                "with the --native-instruments-lib server flag");
-  }
-
 };
 
-Instruments.killAllSim = function (xcodeVersion) {
-  if (xcodeVersion >= "6") {
-    logger.debug("Killall iOS Simulator");
-    exec('pkill -9 -f "iOS Simulator"');
-  } else {
-    logger.debug("Killall iPhoneSimulator");
-    exec('pkill -9 -f iPhoneSimulator');
-  }
+Instruments.killAllSim = function () {
+  xcode.getVersion(function (err, version) {
+    if (err) throw new Error(err);
+
+    if (version >= "6") {
+      logger.debug("Killall iOS Simulator");
+      exec('pkill -9 -f "iOS Simulator"');
+    } else {
+      logger.debug("Killall iPhoneSimulator");
+      exec('pkill -9 -f iPhoneSimulator');
+    }
+  });
 };
 
 Instruments.killAll = function () {
@@ -146,7 +143,7 @@ Instruments.prototype.start = function (cb, unexpectedExitCb) {
   }
   this.exitHandler = unexpectedExitCb;
 
-  this.setInstrumentsPath(function (err) {
+  this.configure(function (err) {
     if (err) {
       logger.error(err.message);
       return cb(err);
@@ -164,6 +161,43 @@ Instruments.prototype.setInstrumentsPath = function (cb) {
     this.instrumentsPath = instrumentsPath;
     cb();
   }.bind(this));
+};
+
+Instruments.prototype.setXcodeVersion = function (cb) {
+  xcode.getVersion(function (err, version) {
+    if (err) return cb(err);
+    this.xcodeVersion = version;
+
+    if (this.xcodeVersion.slice(0, 3) === '6.0' && this.withoutDelay) {
+      logger.info("On xcode 6.0, instruments-without-delay does " +
+                  "not work. If using appium, you can disable instruments-without-delay " +
+                  "with the --native-instruments-lib server flag");
+    }
+
+    if (this.xcodeVersion === "5.0.1") {
+      return cb(new Error("Xcode 5.0.1 ships with a broken version of " +
+                   "Instruments. please upgrade to 5.0.2"));
+    }
+
+    cb();
+  }.bind(this));
+};
+
+Instruments.prototype.setTemplate = function (cb) {
+  if (this.template) return cb();
+  xcode.getAutomationTraceTemplatePath(function (err, path) {
+    if (err) cb(err);
+    this.template = path;
+    cb();
+  }.bind(this));
+};
+
+Instruments.prototype.configure = function (cb) {
+  async.series([
+    this.setXcodeVersion.bind(this),
+    this.setTemplate.bind(this),
+    this.setInstrumentsPath.bind(this)
+  ], cb);
 };
 
 Instruments.prototype.launchHandler = function (err) {
@@ -191,7 +225,7 @@ Instruments.prototype.launchHandler = function (err) {
           waitForLaunch = 1000;
           this.gotFBSOpenApplicationError = false; // clear out for next launch
         } else {
-          Instruments.killAllSim(this.xcodeVersion);
+          Instruments.killAllSim();
         }
         // waiting a bit before restart
         setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "homepage": "https://github.com/appium/appium-instruments",
   "dependencies": {
+    "appium-support" : "=1.0.1",
+    "appium-xcode": "=1.0.1",
     "async": "~0.9.0",
     "through": "~2.3.4",
     "underscore": "~1.7.0",

--- a/test/unit/early-failures-specs.js
+++ b/test/unit/early-failures-specs.js
@@ -2,8 +2,7 @@
 
 var base = require("./base"),
     sinon = base.sinon,
-    Instruments = require('../../lib/main').Instruments,
-    asyncCbStub = require("../utils/stubs").asyncCbStub;
+    Instruments = require('../../lib/main').Instruments;
 
 describe('Early failures', function () {
   var clock;
@@ -13,16 +12,15 @@ describe('Early failures', function () {
 
   it('should call launch cb on setInstrumentsPath failure', function (done) {
     var instruments = new Instruments({});
-    sinon.stub(instruments, "setInstrumentsPath", asyncCbStub(false, 50));
-    var launchCbSpy = sinon.spy();
+    sinon.stub(instruments, "setInstrumentsPath", function (cb) { cb('err'); });
+    var launchCb = function (err) {
+      err.should.exist;
+      unexpectedExitCbSpy.should.not.have.been.called;
+      done();
+    };
     var unexpectedExitCbSpy = sinon.spy();
-    try { instruments.start(launchCbSpy, unexpectedExitCbSpy); } catch (ign) {}
-    clock.tick(49);
-    launchCbSpy.should.not.have.been.called;
-    clock.tick(10);
-    launchCbSpy.should.have.been.calledOnce;
-    unexpectedExitCbSpy.should.not.have.been.called;
-    done();
+
+    instruments.start(launchCb, unexpectedExitCbSpy);
   });
 
   // TODO: update test or move to uiauto
@@ -42,4 +40,3 @@ describe('Early failures', function () {
   // });
 
 });
-


### PR DESCRIPTION
moving around some stuff. appium instruments now uses the new appium-xcode module to get some info, rather than having it passed in with the constructor.

Will squash into one commit before merging.