### PR TITLE
remove '-f' flag from KillallInstruments

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -89,7 +89,7 @@ Instruments.killAllSim = function () {
 
 Instruments.killAll = function () {
   logger.debug("Killall instruments");
-  exec('pkill -9 -f instruments');
+  exec('pkill -9 instruments');
 };
 
 Instruments.getAvailableDevicesWithRetry = function (times, cb) {


### PR DESCRIPTION
If you started appium using the `--instruments` server arg, then when appium tries to kill instruments, it would kill itself ;)