### PR TITLE
Fix killAllSim for Xcode 7

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -77,7 +77,10 @@ Instruments.killAllSim = function () {
     // fails, we couldn't have started simulators anyways/
     if (err) return;
 
-    if (version >= "6") {
+    if (version >= "7") {
+      logger.debug("Killall Simulator");
+      exc("pkill -9 -f Simulator");
+    } else if (version >= "6") {
       logger.debug("Killall iOS Simulator");
       exec('pkill -9 -f "iOS Simulator"');
     } else {


### PR DESCRIPTION
The binary name for the simulator has changed in Xcode 7 from `iOS Simulator` to just `Simulator`. The current `killAllSim` function fails to kill the simulator with Xcode 7, preventing tests from running in my case (Instruments frequently needs a kill-and-restart cycle in order to work).