### PR TITLE
Allow quickLaunch to take an app path

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,9 +130,8 @@ async function getIwdPath(xcodeVersion) {
 // this function launches an instruments test with a default test
 // that immediately passes. In this way we can start a simulator
 // and be notified when it completely launches
-async function quickLaunch (udid) {
+async function quickLaunch (udid, appPath = absoluteTestAppPath.iphonesimulator) {
   let traceTemplatePath = await getXcodeTraceTemplatePath();
-  let appPath = path.resolve(rootDir, 'node_modules', 'ios-test-app', absoluteTestAppPath.iphonesimulator);
   let scriptPath = path.resolve('../assets/blank_instruments_test.js');
   let traceDocument = path.resolve('/', 'tmp', 'testTrace.trace');
   let resultsPath = path.resolve('/', 'tmp');


### PR DESCRIPTION
In the Safari flow, we need files that are created when Safari is launched. So add the ability to do a quick launch with an app path other than the test app.

@sebv.