### PR TITLE
Fix periodic error in which trace document stops quick launch

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,6 +135,10 @@ async function quickLaunch (udid, appPath = path.resolve('../assets/TestApp.app'
   let traceDocument = path.resolve('/', 'tmp', 'testTrace.trace');
   let resultsPath = path.resolve('/', 'tmp');
 
+  // the trace document can be in a weird state
+  // but we never do anything with it, so delete
+  await fs.rimraf(traceDocument);
+
   await exec('xcrun', ['instruments',
                        '-D', traceDocument,
                        '-t', traceTemplatePath,


### PR DESCRIPTION
Every once in a while something goes wrong and the `/tmp/testTrace.trace` directory keeps the quick launch utility from working/ We never actually look at the trace document that is generated, so delete it before we try to launch and everything works great!