### PR TITLE
Update the killAllSim command for xcode7

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -76,8 +76,10 @@ Instruments.killAllSim = function () {
     // this is contrary to our usual pattern, but if getting the xcode version
     // fails, we couldn't have started simulators anyways/
     if (err) return;
-
-    if (version >= "6") {
+    if (version >= "7") {
+      logger.debug("Killall Simulator");
+      exec('pkill -9 -f "Simulator"');
+    } else if (version >= "6") {
       logger.debug("Killall iOS Simulator");
       exec('pkill -9 -f "iOS Simulator"');
     } else {


### PR DESCRIPTION
Xcode 7's simulator is just "Simulator", not "iOS Simulator".  Updating the killAllSim function so that it will actually kill all the simulator processes for Xcode 7 simulators.