### PR TITLE
Error fast when we have ambiguous devices

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -17,6 +17,7 @@ import 'colors';
 
 const ERR_NEVER_CHECKED_IN = 'Instruments never checked in';
 const ERR_CRASHED_ON_STARTUP = 'Instruments crashed on startup';
+const ERR_AMBIGUOUS_DEVICE = 'Instruments Usage Error : Ambiguous device name/identifier';
 
 class Instruments {
   // simple factory with sane defaults
@@ -154,6 +155,11 @@ class Instruments {
       let fbsErrStr = '(FBSOpenApplicationErrorDomain error 8.)';
       if (output.indexOf(fbsErrStr) !== -1) {
         this.gotFBSOpenApplicationError = true;
+      }
+
+      if (output.indexOf(ERR_AMBIGUOUS_DEVICE) !== -1) {
+        let msg = `${ERR_AMBIGUOUS_DEVICE}: '${this.simulatorSdkAndDevice}'`;
+        this.launchResultDeferred.reject(new Error(msg));
       }
     };
     this.proc.stderr.pipe(through(function (output) {

--- a/test/early-failures-specs.js
+++ b/test/early-failures-specs.js
@@ -20,6 +20,4 @@ describe('Early failures', withSandbox({}, (S) => {
     await instruments.launch().should.be.rejectedWith(/ouch!/);
     onExitSpy.should.not.have.been.called;
   });
-
 }));
-


### PR DESCRIPTION
Rather than retrying again and again with the same setup, which will continue to fail, error out.