### PR TITLE
Instruments shutdown timeout - log, don't throw

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -341,7 +341,7 @@ class Instruments {
       this.proc.kill('SIGTERM');
       await termPromise;
       if (!wasTerminated) {
-        throw new Error(`Instruments did not terminate after ${this.termTimeout / 1000} seconds!`);
+        log.debug(`Instruments did not terminate after ${this.termTimeout / 1000} seconds!`);
       }
     }
   }


### PR DESCRIPTION
For some reason we were throwing an error if Instruments didn't shut down in a timely fashion. In Appium 1.4 we [only log a message](https://github.com/appium/appium-instruments/blob/f0a125ddb5a1c42cc82b8ae9621df6b98f778e14/lib/instruments.js#L258).

Resolves https://github.com/appium/appium/issues/6238