### PR TITLE
Update device regexp

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,8 @@ async function getAvailableDevices (timeout = INST_STALL_TIMEOUT) {
     log.errorAndThrow(`Failed getting devices, err: ${err}.`);
   }
   let devices = lines.filter((line) => {
-    return /^.+ \(\d\.\d( Simulator)?\) \[.+\]$/.test(line);
+    // https://regex101.com/r/aE6aS3/1
+    return /^.+ \(\d\.\d( Simulator)?\) \[.+\]( \(Simulator\))?$/.test(line);
   });
   log.debug(`Available devices: ${devices}`);
   return devices;

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -32,7 +32,33 @@ describe('utils', () => {
     });
   }));
   describe('getAvailableDevices', withMocks({tp}, (mocks) => {
-    it('should work for Xcode 7', async () => {
+    it('should work for Xcode 7.3', async () => {
+      let instrumentsOutput = `Known Devices:
+INsaikrisv [C8476FF9-9BC4-5E52-AE3D-536A2E85D43B]
+AppiumParallel1 (9.2) [0120C306-95C1-4196-BC13-4196105EBEF9]
+Apple TV 1080p (9.1) [C5957108-6BA4-4A98-9A83-4BED47EFF1BC]
+iPad 2 (8.4) [B45264A0-551C-41A5-A636-8211C05D8003] (Simulator)
+iPad 2 (9.2) [4444EB1E-BA48-4DFA-B16C-777171FCF3BC] (Simulator)
+iPad Air (8.4) [F26279E7-8BAF-4D7B-ABFE-08D1AC364DCF] (Simulator)`;
+      let devices = [
+        'AppiumParallel1 (9.2) [0120C306-95C1-4196-BC13-4196105EBEF9]',
+        'Apple TV 1080p (9.1) [C5957108-6BA4-4A98-9A83-4BED47EFF1BC]',
+        'iPad 2 (8.4) [B45264A0-551C-41A5-A636-8211C05D8003] (Simulator)',
+        'iPad 2 (9.2) [4444EB1E-BA48-4DFA-B16C-777171FCF3BC] (Simulator)',
+        'iPad Air (8.4) [F26279E7-8BAF-4D7B-ABFE-08D1AC364DCF] (Simulator)'
+      ];
+      mocks.tp
+        .expects('exec')
+        .once()
+        .returns(Promise.resolve({stdout: '/a/b/c/d\n', stderr:'' }));
+      mocks.tp
+        .expects('exec')
+        .once()
+        .returns(Promise.resolve({stdout: instrumentsOutput, stderr:'' }));
+        (await utils.getAvailableDevices()).should.deep.equal(devices);
+        verify(mocks);
+    });
+    it('should work for Xcode 7.0-7.2', async () => {
       let instrumentsOutput = `Known Devices:
 INsaikrisv [C8476FF9-9BC4-5E52-AE3D-536A2E85D43B]
 AppiumParallel1 (9.2) [0120C306-95C1-4196-BC13-4196105EBEF9]


### PR DESCRIPTION
Xcode 7.3 changed how it lists devices available to Instruments.

Previously a simulator would be listed as either

```
// Xcode 7.0-7.2
iPhone 6s Plus (9.1) [D325C63A-18DA-4053-A394-357644CCFA03]

// Xcode 6.*
iPhone 6 (8.4 Simulator) [D325C63A-18DA-4053-A394-357644CCFA03]
```

Now it comes out as

```
// Xcode 7.3
iPad Air 2 (9.0) [27BB8643-797D-491F-9C76-C54217282147] (Simulator)
```

Updated the regular expression to reflect this change, so that we can get devices. See [here](https://regex101.com/r/aE6aS3/1) for details of the regexp.