### PR TITLE
Allow plain text process arguments

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -254,13 +254,19 @@ class Instruments {
       // any additional stuff specified by the user
 
       if (_.isString(this.processArguments)) {
-        for (let arg of this.processArguments.split('-e ')) {
-          arg = arg.trim();
-          if (arg.length) {
-            let space = arg.indexOf(' ');
-            let flag = arg.substring(0, space);
-            let value = arg.substring(space + 1);
-            args.push('-e', flag, value);
+        if (this.processArguments.indexOf('-e') === -1) {
+          log.debug('Plain string process arguments being pushed into arguments');
+          args.push(this.processArguments);
+        } else {
+          log.debug('Environment variables being pushed into arguments');
+          for (let arg of this.processArguments.split('-e ')) {
+            arg = arg.trim();
+            if (arg.length) {
+              let space = arg.indexOf(' ');
+              let flag = arg.substring(0, space);
+              let value = arg.substring(space + 1);
+              args.push('-e', flag, value);
+            }
           }
         }
       } else {

--- a/test/instruments-specs.js
+++ b/test/instruments-specs.js
@@ -104,6 +104,33 @@ describe('instruments', () => {
 
       verify(mocks);
     });
+    it('should properly handle non-environment-variable process arguments', async () => {
+      let instruments = new Instruments({});
+      instruments.processArguments = 'some random process arguments';
+      instruments.xcodeVersion = XCODE_VERSION;
+      instruments.template = '/a/b/c/d/tracetemplate';
+      instruments.instrumentsPath = '/a/b/c/instrumentspath';
+      mocks.fs.expects('exists').once().returns(Promise.resolve(false));
+      mocks.tp.expects('spawn').once()
+        .withArgs(
+          sinon.match(instruments.instrumentsPath),
+          // sinon.match.string,
+          ["-t", "/a/b/c/d/tracetemplate",
+           "-D", "/tmp/appium-instruments/instrumentscli0.trace", undefined,
+           "some random process arguments",
+           "-e", "UIASCRIPT", undefined,
+           "-e", "UIARESULTSPATH", "/tmp/appium-instruments"],
+          sinon.match.object
+        )
+        .returns({});
+      mocks.utils
+        .expects('getIwdPath')
+        .once()
+        .returns(Promise.resolve('/a/b/c/iwd'));
+      await instruments.spawnInstruments();
+
+      verify(mocks);
+    });
     it('should properly handle process arguments as hash', async () => {
       let instruments = new Instruments({});
       instruments.processArguments = {firstoption: 'firstoptionsarg', secondoption: 'second option arg'};


### PR DESCRIPTION
Is a user passes in a process argument string that has no `-e` in it, just pass it along to Instruments.

Addresses #67 