### PR TITLE
Add space to process argument check for "-e"

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -254,7 +254,7 @@ class Instruments {
       // any additional stuff specified by the user
 
       if (_.isString(this.processArguments)) {
-        if (this.processArguments.indexOf('-e') === -1) {
+        if (this.processArguments.indexOf('-e ') === -1) {
           log.debug('Plain string process arguments being pushed into arguments');
           args.push(this.processArguments);
         } else {


### PR DESCRIPTION
When splitting the process argument string, "-e " is used as the separator. When determining whether to pass the raw string, we should also include the space. Otherwise, a process argument such as "-environment localhost" would be handled incorrectly and sent as "-e -environment localhost".

All unit tests pass. There were functional failures unrelated to this change (failed before and after), and I didn't want to invest too much time in diagnosing them.

```
 42  -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_,------,
 0   -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_|   /\_/\
 0   -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-^|__( ^ .^)
     -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-  ""  ""

  42 passing (300ms)
```