### PR TITLE
Try harder to kill Instruments

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -351,23 +351,28 @@ class Instruments {
 
   /* PROCESS MANAGEMENT */
   async shutdown () {
-    if (this.proc) {
-      log.debug('Starting shutdown.');
-      let wasTerminated = false;
-      // monitoring process termination
-      let termDelay = cancellableDelay(this.termTimeout);
-      let termPromise = termDelay.catch(B.CancellationError, () => {});
-      this.setExitListener(() => {
-        this.proc = null;
-        wasTerminated = true;
-        termDelay.cancel();
-        this.onShutdownDeferred.resolve();
-      });
-      log.debug('Sending sigterm to instruments');
-      this.proc.kill('SIGTERM');
-      await termPromise;
-      if (!wasTerminated) {
-        throw new Error(`Instruments did not terminate after ${this.termTimeout / 1000} seconds!`);
+    if (!this.proc) return;
+    
+    log.debug('Starting shutdown.');
+    let wasTerminated = false;
+    // monitoring process termination
+    let termDelay = cancellableDelay(this.termTimeout);
+    let termPromise = termDelay.catch(B.CancellationError, () => {});
+    this.setExitListener(() => {
+      this.proc = null;
+      wasTerminated = true;
+      termDelay.cancel();
+      this.onShutdownDeferred.resolve();
+    });
+    log.debug('Sending sigterm to instruments');
+    this.proc.kill('SIGTERM');
+    await termPromise;
+    if (!wasTerminated) {
+      log.warn(`Instruments did not terminate after ${this.termTimeout / 1000} seconds!`);
+      log.debug('Sending SIGKILL');
+      this.proc.kill('SIGKILL');
+      if (_.isFunction(this.exitListener)) {
+        this.exitListener();
       }
     }
   }


### PR DESCRIPTION
If we leave the Instruments process running, and many tests are run, they build up and affect the running of tests (see #72). So try to send a `SIGKILL` signal if `SIGTERM` didn't work.

