### PR TITLE
Remove <Type> from PlistBuddy Set commands.

### DIFF
--- a/bin/xcode-iwd.sh
+++ b/bin/xcode-iwd.sh
@@ -13,12 +13,12 @@ if /usr/libexec/PlistBuddy -c "Add :EnvironmentVariables:DYLD_INSERT_LIBRARIES s
     echo "Added :EnvironmentVariables:DYLD_INSERT_LIBRARIES"
 else
     echo ":EnvironmentVariables:DYLD_INSERT_LIBRARIES already exists. Resetting."
-    /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:DYLD_INSERT_LIBRARIES string $iwd_path/DTMobileISShim.dylib" $plist_path
+    /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:DYLD_INSERT_LIBRARIES $iwd_path/DTMobileISShim.dylib" $plist_path
 fi
 
 if /usr/libexec/PlistBuddy -c "Add :EnvironmentVariables:LIB_PATH string $iwd_path/" $plist_path ; then
     echo "Added :EnvironmentVariables:LIB_PATH"
 else
     echo ":EnvironmentVariables:LIB_PATH already exists. Resetting."
-    /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:LIB_PATH string $iwd_path/" $plist_path
+    /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:LIB_PATH $iwd_path/" $plist_path
 fi


### PR DESCRIPTION
`/usr/libexec/PlistBuddy -h` suggests `<Type>` should be excluded when
calling the `Set` command.

`Set <Entry> <Value>` - Sets the value at Entry to Value
`Add <Entry> <Type> [<Value>]` - Adds Entry to the plist, with value Value

When `Set` includes `<Type>` the resulting property list entry includes `string` in the value:
`<key>DYLD_INSERT_LIBRARIES</key>
<string>string ~/.nvm/versions/node/v6.3.1/lib/node_modules/appium-instruments/thirdparty/iwd7/DTMobileISShim.dylib</string>`

Here is a script to test it: 
> \#!/usr/bin/env bash

> nvm install node
> nvm alias default node
> nvm use node

> node_version=$(node --version)

> npm install -g appium
> npm install -g wd
> npm install -g appium-instruments

> xcode_path="/Applications/Xcode.app"
> appium_instruments_path="$HOME/.nvm/versions/node/$node_version/lib/node_modules/appium-instruments"

> sh "${appium_instruments_path}/bin/xcode-iwd.sh" "$xcode_path" "${appium_instruments_path}"