### PR TITLE
Kill just only current running instrument process

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -9,8 +9,7 @@ import { mkdirp, fs, cancellableDelay } from 'appium-support';
 import xcode from 'appium-xcode';
 import B from 'bluebird';
 import { killAllSimulators } from 'appium-ios-simulator';
-import { killAllInstruments, getInstrumentsPath, parseLaunchTimeout,
-         getIwdPath } from './utils';
+import { getInstrumentsPath, parseLaunchTimeout, getIwdPath } from './utils';
 import { outputStream, errorStream, webSocketAlertStream, dumpStream } from './streams';
 import 'colors';
 
@@ -118,8 +117,9 @@ class Instruments {
 
     this.exitListener = null;
     this.proc = await this.spawnInstruments();
-    this.proc.on('exit', (code) => {
-      log.debug(`Instruments exited with code ${code}`);
+    this.proc.on('exit', (code, signal) => {
+      const msg = code !== null ? `code: ${code}` : `signal: ${signal}`;
+      log.debug(`Instruments exited with ${msg}`);
     });
 
     // set up the promise to handle launch
@@ -150,7 +150,8 @@ class Instruments {
     let actOnStderr = (output) => {
       if (this.launchTimeout.afterSimLaunch && output && output.match(/CLTilesManagerClient: initialize/)) {
         this.addSocketConnectTimer(this.launchTimeout.afterSimLaunch, 'afterLaunch', async () => {
-          await killAllInstruments();
+          await this.killInstruments();
+          this.launchResultDeferred.reject(new Error(ERR_NEVER_CHECKED_IN));
         });
       }
 
@@ -173,7 +174,8 @@ class Instruments {
 
     // start waiting for instruments to launch successfully
     this.addSocketConnectTimer(this.launchTimeout.global, 'global', async () => {
-      await killAllInstruments();
+      await this.killInstruments();
+      this.launchResultDeferred.reject(new Error(ERR_NEVER_CHECKED_IN));
     });
 
     try {
@@ -181,9 +183,10 @@ class Instruments {
     } finally {
       this.clearSocketConnectTimers();
     }
-    this.setExitListener((code) => {
+    this.setExitListener((code, signal) => {
       this.proc = null;
-      this.onShutdownDeferred.reject(new Error(`Abnormal exit with code: ${code}`));
+      const msg = code !== null ? `code: ${code}` : `signal: ${signal}`;
+      this.onShutdownDeferred.reject(new Error(`Abnormal exit with ${msg}`));
     });
   }
 
@@ -324,10 +327,6 @@ class Instruments {
     let socketConnectDelay = cancellableDelay(delay);
     socketConnectDelay.then(() => {
       log.warn(`Instruments socket client never checked in; timing out (${type})`);
-      this.setExitListener(() => {
-        this.proc = null;
-        this.launchResultDeferred.reject(new Error(ERR_NEVER_CHECKED_IN));
-      });
       return doAction();
     }).catch(B.CancellationError, () => {}).done();
     this.socketConnectDelays.push(socketConnectDelay);
@@ -349,32 +348,40 @@ class Instruments {
     this.proc.on('exit', exitListener);
   }
 
-  /* PROCESS MANAGEMENT */
-  async shutdown () {
+  killInstruments () {
     if (!this.proc) return;
 
-    log.debug('Starting shutdown.');
-    let wasTerminated = false;
-    // monitoring process termination
-    let termDelay = cancellableDelay(this.termTimeout);
-    let termPromise = termDelay.catch(B.CancellationError, () => {});
-    this.setExitListener(() => {
-      this.proc = null;
-      wasTerminated = true;
-      termDelay.cancel();
-      this.onShutdownDeferred.resolve();
-    });
-    log.debug('Sending sigterm to instruments');
-    this.proc.kill('SIGTERM');
-    await termPromise;
-    if (!wasTerminated) {
-      log.warn(`Instruments did not terminate after ${this.termTimeout / 1000} seconds!`);
-      log.debug('Sending SIGKILL');
-      this.proc.kill('SIGKILL');
-      if (_.isFunction(this.exitListener)) {
-        this.exitListener();
+    log.debug('Kill instruments');
+    return new B(async (resolve) => {
+      let wasTerminated = false;
+      // monitoring process termination
+      let termDelay = cancellableDelay(this.termTimeout);
+      let termPromise = termDelay.catch(B.CancellationError, () => {});
+      this.setExitListener(() => {
+        this.proc = null;
+        wasTerminated = true;
+        termDelay.cancel();
+        resolve();
+      });
+      log.debug('Sending SIGTERM');
+      this.proc.kill('SIGTERM');
+      await termPromise;
+      if (!wasTerminated) {
+        log.warn(`Instruments did not terminate after ${this.termTimeout / 1000} seconds!`);
+        log.debug('Sending SIGKILL');
+        this.proc.kill('SIGKILL');
+        if (_.isFunction(this.exitListener)) {
+          this.exitListener();
+        }
       }
-    }
+    });
+  }
+
+  /* PROCESS MANAGEMENT */
+  async shutdown () {
+    log.debug('Starting shutdown.');
+    await this.killInstruments();
+    this.onShutdownDeferred.resolve();
   }
 }
 


### PR DESCRIPTION
I fixed for this issue: https://github.com/appium/appium-instruments/issues/78
When I decrease the launchTimeout from 90000 to 20000. However when the appium-instrument got timeout, it kill all instrument processes in desktop even the instruments were running in other iOS devices. That's not good solution, I modified by just kill the current blocking instrument process. The fix the leak instruments, the appium-ios-driver should handle it by call appium-instrument shutdown