### PR TITLE
Append language and locale arguments to instruments when given

### DIFF
--- a/lib/instruments.js
+++ b/lib/instruments.js
@@ -65,7 +65,7 @@ class Instruments {
     // config
     for (let f of ['app', 'termTimeout', 'flakeyRetries', 'udid', 'bootstrap',
                    'template', 'withoutDelay', 'processArguments', 'realDevice',
-                   'simulatorSdkAndDevice', 'tmpDir', 'traceDir']) {
+                   'simulatorSdkAndDevice', 'tmpDir', 'traceDir', 'locale', 'language']) {
       this[f] = opts[f];
     }
     this.traceDir = this.traceDir || this.tmpDir;
@@ -282,6 +282,13 @@ class Instruments {
     }
     args = args.concat(['-e', 'UIASCRIPT', this.bootstrap]);
     args = args.concat(['-e', 'UIARESULTSPATH', this.tmpDir]);
+    if (this.language) {
+      args = args.concat([`-AppleLanguages (${this.language})`]);
+      args = args.concat([`-NSLanguages (${this.language})`]);
+    }
+    if (this.locale) {
+      args = args.concat([`-AppleLocale ${this.locale}`]);
+    }
 
     let env = _.clone(process.env);
     if (this.xcodeVersion.major >= 7 && !this.udid) {

--- a/test/instruments-specs.js
+++ b/test/instruments-specs.js
@@ -158,5 +158,35 @@ describe('instruments', () => {
 
       verify(mocks);
     });
+    it('should add language and locale arguments when appropriate', async () => {
+      let instruments = new Instruments({locale: "de_DE", language: "de"});
+      instruments.processArguments = 'some random process arguments';
+      instruments.xcodeVersion = XCODE_VERSION;
+      instruments.template = '/a/b/c/d/tracetemplate';
+      instruments.instrumentsPath = '/a/b/c/instrumentspath';
+      mocks.fs.expects('exists').once().returns(Promise.resolve(false));
+      mocks.tp.expects('spawn').once()
+        .withArgs(
+          sinon.match(instruments.instrumentsPath),
+          // sinon.match.string,
+          ["-t", "/a/b/c/d/tracetemplate",
+           "-D", "/tmp/appium-instruments/instrumentscli0.trace", undefined,
+           "some random process arguments",
+           "-e", "UIASCRIPT", undefined,
+           "-e", "UIARESULTSPATH", "/tmp/appium-instruments",
+           "-AppleLanguages (de)",
+           "-NSLanguages (de)",
+           "-AppleLocale de_DE"],
+          sinon.match.object
+        )
+        .returns({});
+      mocks.utils
+        .expects('getIwdPath')
+        .once()
+        .returns(Promise.resolve('/a/b/c/iwd'));
+      await instruments.spawnInstruments();
+
+      verify(mocks);
+    });
   }));
 });


### PR DESCRIPTION
With the right arguments, Instruments will launch an app into a particular locale and language. With this pull request, once appium-ios-driver passes the locale and language in, Instruments will be launched with these arguments.